### PR TITLE
VS2012コンパイルエラー対応＋設定ファイルエラー処理の修正

### DIFF
--- a/src/st_table.c
+++ b/src/st_table.c
@@ -1,6 +1,8 @@
 #ifdef _MSC_VER //<OKA>
 #pragma warning(disable:4786)
+#if _MSC_VER < 1700
 #define for if(0);else for
+#endif
 #endif          //</OKA>
 #include "st_table.h"
 #include "tc.h"

--- a/src/tcode.c
+++ b/src/tcode.c
@@ -6,7 +6,9 @@
 #include "debug.h"
 
 #ifdef _MSC_VER //<OKA>
+#if _MSC_VER < 1700
 #define for if(0);else for
+#endif
 #endif          //</OKA>
 
 /* -------------------------------------------------------------------


### PR DESCRIPTION
- for(int i=...)に関するVC6用対策コードがVS2012ではねられてしまうようになった。
- EVENT_SYSTEM_FOREGROUNDをフックするタイミングが早すぎて、
  warn()またはerror()によるエラーダイアログが表示されなかった。(2011-07-10版～)
